### PR TITLE
Check activeColorTable null first

### DIFF
--- a/AvaloniaGif/Decoding/GifDecoder.cs
+++ b/AvaloniaGif/Decoding/GifDecoder.cs
@@ -218,7 +218,7 @@ namespace AvaloniaGif.Decoding
                 {
                     var indexColor = _frameIndexSpan.Span[indexOffset + i];
 
-                    if (targetOffset >= len | indexColor >= activeColorTable.Length | activeColorTable == null) return;
+                    if (activeColorTable == null || targetOffset >= len || indexColor >= activeColorTable.Length) return;
 
                     if (!(hT & indexColor == tC))
                         _bitmapBackBuffer[targetOffset] = activeColorTable[indexColor];


### PR DESCRIPTION
I've noticed that if I have my application paused at a breakpoint for a while (eg 5 minutes) then try to continue debugging, I often get an unhandled exception thrown with the following details:
```
Object reference not set to an instance of an object. (activeColorTable was null)
at AvaloniaGif.Decoding.GifDecoder.<>c__DisplayClass40_0.<DrawFrame>g__DrawRow|0(Int32 row) in C:\Users\derek\source\repos\derekantrican\MyApplication\external\avaloniagif\AvaloniaGif\Decoding\GifDecoder.cs:line 221
```

This line *does* check if `activeColorTable` is null, but it does it *after* attempting to access a property (`activeColorTable.Length`) and it uses the single pipe operator, which means that all conditions are checked before evaluating if `return;` should be run ([for this reason, the single pipe operator should not be used if there is a null check](https://stackoverflow.com/a/35314/2246411)). *I haven't checked elsewhere in the code base for the use of single pipe `|` or single ampersand `&` operators but I would caution against using them for the reasons in the link above.*

Let me know if you have any questions